### PR TITLE
upadated links for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ To install tests-app, follow these steps:
 
 1. Clone the repository
 ```sh
-git clone https://github.com/vGerJ02/ruxailab-testing-app
+git clone https://github.com/ruxailab/heatmap-app.git
 ```
 
 2. Navigate to the project directory
 ```sh
-cd ruxailab-testing-app
+cd heatmap-app
 ```
 
 3. Install the dependencies


### PR DESCRIPTION
Updated the links and commands written in the Readme.md file to work with the name of the repository.

Issue-
previous commands were not working with the clone link for the repository.
![Screenshot 2025-02-06 185510](https://github.com/user-attachments/assets/430d29a1-911a-4f36-814d-929a486b6896)
![Screenshot 2025-02-06 185519](https://github.com/user-attachments/assets/d5d9aa94-df7a-4ead-9360-25dd9435057b)


After the changes-
![Screenshot 2025-02-06 185538](https://github.com/user-attachments/assets/366667e8-2600-49a9-b161-b9d5cbef4c8a)
