### PR TITLE
fix: adding correct link in main.js

### DIFF
--- a/electron-src/main.js
+++ b/electron-src/main.js
@@ -120,7 +120,7 @@ function createMenu() {
             label: 'Documentation',
             click: () => {
                 shell.openExternal(
-                    'https://github.com/vGerJ02/ruxailab-testing-app/wiki',
+                    'https://github.com/ruxailab/heatmap-app',
                 )
             },
         }),
@@ -130,7 +130,7 @@ function createMenu() {
             label: 'Check for Updates',
             click: () => {
                 shell.openExternal(
-                    'https://github.com/vGerJ02/ruxailab-testing-app/releases',
+                    'https://github.com/ruxailab/heatmap-app/releases',
                 )
             },
         }),
@@ -140,7 +140,7 @@ function createMenu() {
             label: 'Report an Issue',
             click: () => {
                 shell.openExternal(
-                    'https://github.com/vGerJ02/ruxailab-testing-app/issues',
+                    'https://github.com/vGerJ02/ruxailab-testing-app/issues',//currently the issue section is not opened
                 )
             },
         }),


### PR DESCRIPTION

 update the link with the RUXAILAB repo's link
Before Update:
![Screenshot 2025-03-25 231516](https://github.com/user-attachments/assets/2bc23cfc-be27-430a-9509-872dd3ff3fa5)
After Update:
![Screenshot 2025-03-25 231530](https://github.com/user-attachments/assets/a985a6ed-12d2-49a1-a3b5-691a387d3f71)
